### PR TITLE
Fix build wheels and add back testpypi publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Publish Python 🐍 distribution 📦 to PyPI
+name: Publish Python 🐍 distribution 📦 to PyPI and TestPyPI
 
 on: push
 
@@ -20,7 +20,7 @@ jobs:
           build
           --user
       - name: Build a binary wheel and a source tarball
-        run: python3 -m build
+        run: python3 -m build -w -s
       - name: Store the distribution packages
         uses: actions/upload-artifact@v4
         with:
@@ -62,7 +62,7 @@ jobs:
 
     steps:
       - name: Download all the dists
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: python-package-distributions
           path: dist/
@@ -90,3 +90,27 @@ jobs:
           gh release upload
           '${{ github.ref_name }}' dist/**
           --repo '${{ github.repository }}'
+
+  publish-to-testpypi:
+    name: Publish Python 🐍 distribution 📦 to TestPyPI
+    needs:
+      - build
+    runs-on: ubuntu-latest
+
+    environment:
+      name: testpypi
+      url: https://test.pypi.org/p/pekat-vision-sdk
+
+    permissions:
+      id-token: write # IMPORTANT: mandatory for trusted publishing
+
+    steps:
+      - name: Download all the dists
+        uses: actions/download-artifact@v4
+        with:
+          name: python-package-distributions
+          path: dist/
+      - name: Publish distribution 📦 to TestPyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ maintainers = [{ email = "developers@pekatvision.com" }]
 keywords = ["pekat", "pekatvision", "pekatvisionsdk", "vision", "sdk"]
 classifiers = [
     "Development Status :: 5 - Production/Stable",
+    "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3 :: Only",
@@ -37,7 +38,6 @@ packages = ["src/PekatVisionSDK"]
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/PekatVisionSDK"]
-
 
 [tool.hatch.envs.test]
 dependencies = ["pytest", "requests", "numpy", "packaging"]


### PR DESCRIPTION
Running `python3 -m build` doesn't include the `PekatVisionSDK` directory in the wheel.

Running `python3 -m build -w` along with specifying the `[tool.hatch.build.targets.wheel]` in `pyproject.toml` does.