### PR TITLE
Fix `AttributeError` when stopping a remote `Instance / Analyzer`

### DIFF
--- a/src/PekatVisionSDK/instance.py
+++ b/src/PekatVisionSDK/instance.py
@@ -100,6 +100,7 @@ class Instance:
         self.wait_for_init_model = wait_for_init_model
         self.gpu = gpu
 
+        self.process: Optional[subprocess.Popen] = None
         self.stop_key: Optional[str] = None
 
         if port is None:


### PR DESCRIPTION
If Instance was created with `already_running == True`, `Instance.process` was not defined.
This change adds the attribute to the `__init__` method.