### PR TITLE
Use shared memory for analyzing locally

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ classifiers = [
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3 :: Only",
 ]
-dependencies = ["numpy", "requests", "packaging"]
+dependencies = ["numpy", "requests", "packaging", "netifaces2"]
 
 [project.optional-dependencies]
 opencv = ["opencv-python"]
@@ -60,6 +60,8 @@ dependencies = [
     "black",
     "ruff",
     "mypy",
+    "netifaces2",
+    "rich",
 ]
 
 [tool.hatch.envs.docs]

--- a/src/PekatVisionSDK/instance.py
+++ b/src/PekatVisionSDK/instance.py
@@ -337,10 +337,7 @@ class Instance:
 
         This method will run if the project is running locally.
         """
-        (height, width), channels = (
-            image.shape[:2],
-            image.shape[2] if len(image.shape) == 3 else 1,
-        )
+        height, width = image.shape[:2]
 
         if self._shm_arr.shape != image.shape:
             self._shm.close()
@@ -358,7 +355,6 @@ class Instance:
             data=data,
             height=height,
             width=width,
-            channels=channels,
             name=self._shm.name,
         )
 

--- a/src/PekatVisionSDK/instance.py
+++ b/src/PekatVisionSDK/instance.py
@@ -342,7 +342,7 @@ class Instance:
             image.shape[2] if len(image.shape) == 3 else 1,
         )
 
-        if image.nbytes != self._shm.size:
+        if self._shm_arr.shape != image.shape:
             self._shm.close()
             self._shm = shared_memory.SharedMemory(create=True, size=image.nbytes)
             self._shm_arr = np.ndarray(

--- a/src/PekatVisionSDK/instance.py
+++ b/src/PekatVisionSDK/instance.py
@@ -275,7 +275,7 @@ class Instance:
         self,
         path: UrlEndpoint,
         response_type: ResponseType,
-        **kwargs: Dict[str, Any],
+        **kwargs: Any,  # noqa: ANN401
     ) -> str:
         url = f"http://{self.host}:{self.port}/{path}?response_type={response_type}"
 


### PR DESCRIPTION
New behavior of the analyzer:

* The `analyze` method will decide, whether to use shared memory or not based on whether running locally and PEKAT VISION server version
* If using shared memory, a HTTP request will be sent to the running PEKAT VISION instance with the name of the shared memory in which raw image bytes are stored.
