### PR TITLE
Create attributes before an exception can be raised

### DIFF
--- a/src/PekatVisionSDK/instance.py
+++ b/src/PekatVisionSDK/instance.py
@@ -117,6 +117,9 @@ class Instance:
         self.wait_for_init_model = wait_for_init_model
         self.gpu = gpu
 
+        self._shm = shared_memory.SharedMemory(create=True, size=1)
+        self._shm_arr = np.ndarray((1,), dtype=np.uint8, buffer=self._shm.buf)
+
         self.session = requests.Session()  # Session for all requests
 
         self.process: Optional[subprocess.Popen] = None
@@ -138,9 +141,6 @@ class Instance:
             self.ping()
 
         self.__stopping = False
-
-        self._shm = shared_memory.SharedMemory(create=True, size=1)
-        self._shm_arr = np.ndarray((1,), dtype=np.uint8, buffer=self._shm.buf)
 
         self._is_local = self.host in [
             *_get_local_addressses(),

--- a/src/PekatVisionSDK/instance.py
+++ b/src/PekatVisionSDK/instance.py
@@ -148,7 +148,7 @@ class Instance:
             "localhost",
         ]
 
-    def __del__(self):
+    def __del__(self) -> None:
         if not self.already_running:
             self.stop()
         self._shm.close()

--- a/src/PekatVisionSDK/instance.py
+++ b/src/PekatVisionSDK/instance.py
@@ -127,6 +127,13 @@ class Instance:
 
         self._rng = np.random.default_rng()
 
+        self.__stopping = False
+
+        self._is_local = self.host in [
+            *_get_local_addresses(),
+            "127.0.0.1",
+            "localhost",
+        ]
         if port is None:
             self.port = self._find_free_ports()
             self.port_is_defined = False
@@ -139,14 +146,6 @@ class Instance:
 
         if ping:
             self.ping()
-
-        self.__stopping = False
-
-        self._is_local = self.host in [
-            *_get_local_addresses(),
-            "127.0.0.1",
-            "localhost",
-        ]
 
     def __del__(self) -> None:
         if not self.already_running:

--- a/src/PekatVisionSDK/instance.py
+++ b/src/PekatVisionSDK/instance.py
@@ -43,7 +43,7 @@ UrlEndpoint = Literal[
 ALLOWED_RESPONSE_TYPES = get_args(ResponseType)
 
 
-def _get_local_addressses() -> List[str]:
+def _get_local_addresses() -> List[str]:
     return [
         addr["addr"]
         for interface in netifaces.interfaces()
@@ -143,7 +143,7 @@ class Instance:
         self.__stopping = False
 
         self._is_local = self.host in [
-            *_get_local_addressses(),
+            *_get_local_addresses(),
             "127.0.0.1",
             "localhost",
         ]


### PR DESCRIPTION
This is not an ideal fix, ideally, __init__ would contain nothing that can raise an exception.

As it is written on [Wikipedia](https://en.wikipedia.org/wiki/Constructor_(object-oriented_programming)):

> A properly written constructor leaves the resulting object in a valid state.

Closes #41 